### PR TITLE
Add polygon annotations

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
+    "@mapbox/mapbox-gl-draw": "^1.3.0",
     "@mui/lab": "^5.0.0-alpha.68",
     "@mui/material": "^5.4.1",
     "@testing-library/jest-dom": "^5.16.1",
@@ -12,6 +13,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/geojson": "^7946.0.8",
     "@types/jest": "^27.4.0",
+    "@types/mapbox__mapbox-gl-draw": "^1.2.3",
     "@types/mapbox-gl": "^2.6.0",
     "@types/node": "^16.11.21",
     "@types/react": "^17.0.38",

--- a/frontend/src/components/AnnotationBar.tsx
+++ b/frontend/src/components/AnnotationBar.tsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import './AnnotationBar.css';
 
-function AnnotationBar() {
+interface AnnotationBarProps {
+  onAnnotationModeChange: Function,
+}
+
+function AnnotationBar({
+  onAnnotationModeChange,
+}: AnnotationBarProps) {
+  const updateMode = (updatedMode: string) => {
+    onAnnotationModeChange(updatedMode);
+  };
+
   return (
     <div className="annotation-bar-container">
-      <p className="annotation-button">BUTTONS HERE</p>
+      <button className="annotation-button" type="button" onClick={() => updateMode('point')}>Point</button>
       <h3 className="annotation-label">Annotation Tools</h3>
     </div>
   );

--- a/frontend/src/components/AnnotationBar.tsx
+++ b/frontend/src/components/AnnotationBar.tsx
@@ -2,19 +2,21 @@ import React from 'react';
 import './AnnotationBar.css';
 
 interface AnnotationBarProps {
-  onAnnotationModeChange: Function,
+  onAnnotationModeSelect: Function,
 }
 
 function AnnotationBar({
-  onAnnotationModeChange,
+  onAnnotationModeSelect,
 }: AnnotationBarProps) {
   const updateMode = (updatedMode: string) => {
-    onAnnotationModeChange(updatedMode);
+    onAnnotationModeSelect(updatedMode);
   };
 
   return (
     <div className="annotation-bar-container">
-      <button className="annotation-button" type="button" onClick={() => updateMode('point')}>Point</button>
+      <button className="annotation-button-polygon" type="button" onClick={() => updateMode('polygon')}>Polygon</button>
+      <button className="annotation-button-text" type="button" onClick={() => updateMode('text')}>Text</button>
+      <button className="annotation-button-off" type="button" onClick={() => updateMode('off')}>X</button>
       <h3 className="annotation-label">Annotation Tools</h3>
     </div>
   );

--- a/frontend/src/components/MapPanel.tsx
+++ b/frontend/src/components/MapPanel.tsx
@@ -81,6 +81,10 @@ function MapPanel({
     }
   };
 
+  const updateAnnotationMode = (updatedMode: string) => {
+    console.log(updatedMode);
+  };
+
   useEffect(() => {
     if (!mapRef.current) {
       (mapRef as any).current = new mapboxgl.Map({
@@ -126,7 +130,9 @@ function MapPanel({
           <button className="search-button" type="button" onClick={updateSearch}>Search Area</button>
         )
         : (
-          <AnnotationBar />
+          <AnnotationBar
+            onAnnotationModeChange={updateAnnotationMode}
+          />
         )}
     </div>
   );

--- a/frontend/src/components/MapRenderer.ts
+++ b/frontend/src/components/MapRenderer.ts
@@ -28,7 +28,6 @@ export function updateDataSources(
     const reportSource: mapboxgl.GeoJSONSource = map.getSource('reports') as mapboxgl.GeoJSONSource;
     const relationshipSource: mapboxgl.GeoJSONSource = map.getSource('relationships') as mapboxgl.GeoJSONSource;
     const boxSource: mapboxgl.GeoJSONSource = map.getSource('box') as mapboxgl.GeoJSONSource;
-    const pointAnnotationSource: mapboxgl.GeoJSONSource = map.getSource('points') as mapboxgl.GeoJSONSource;
 
     reportSource.setData({
       type: 'FeatureCollection',
@@ -54,22 +53,6 @@ export function updateDataSources(
     const layerIds = map.getStyle().layers?.map((item) => item.id).filter((s) => s.includes('gl-draw'));
     layerIds?.forEach((id) => {
       map.setLayoutProperty(id, 'visibility', isSearchMode ? 'none' : 'visible');
-    });
-
-    pointAnnotationSource.setData({
-      type: 'FeatureCollection',
-      features: annotations.points.map((point) => (
-        {
-          type: 'Feature',
-          geometry: {
-            type: 'Point',
-            coordinates: isSearchMode ? [] : [point.lnglat.lng, point.lnglat.lat],
-          },
-          properties: {
-            name: 'Annotation Point',
-          },
-        }
-      )),
     });
   }
 }
@@ -115,24 +98,6 @@ function setupDataSources(
         properties: {
           title: 'bounding box',
         },
-      },
-    });
-    map.addSource('points', {
-      type: 'geojson',
-      data: {
-        type: 'FeatureCollection',
-        features: annotations.points.map((point) => (
-          {
-            type: 'Feature',
-            geometry: {
-              type: 'Point',
-              coordinates: [point.lnglat.lng, point.lnglat.lat],
-            },
-            properties: {
-              name: 'Annotation Point',
-            },
-          }
-        )),
       },
     });
   }

--- a/frontend/src/components/SelectedProjectPage.tsx
+++ b/frontend/src/components/SelectedProjectPage.tsx
@@ -27,9 +27,12 @@ function SelectedProjectPage() {
   const [relationships, setRelationships] = useState([]);
   const [dateRange, setDateRange] = useState({} as DateRangeProperties);
   const [annotations, setAnnotations] = useState({
-    point: [],
-    polygon: [],
-    text: [],
+    points: [],
+    polygons: {
+      type: 'FeatureCollection',
+      features: [],
+    },
+    texts: [],
   } as Annotations);
   const [isSearchMode, setIsSearchMode] = useState(true);
 

--- a/frontend/src/models/types.ts
+++ b/frontend/src/models/types.ts
@@ -1,3 +1,6 @@
+import { FeatureCollection } from 'geojson';
+import { LngLat } from 'mapbox-gl';
+
 export type BoundingBox = [[number, number], [number, number]];
 
 export interface SearchParameters {
@@ -34,10 +37,19 @@ export type DateRangeProperties = {
   newestYearMonth: number[],
 }
 
+export type PointAnnotation = {
+  lnglat: LngLat;
+}
+
+export type TextAnnotation = {
+  lnglat: LngLat;
+  text: string;
+}
+
 export type Annotations = {
-  point: number[],
-  polygon: number[],
-  text: string[],
+  points: PointAnnotation[],
+  polygons: FeatureCollection,
+  texts: TextAnnotation[],
 }
 
 export type RelationshipFeature = {


### PR DESCRIPTION
You can add point annotations if you go to notebook mode, click "point", and click anywhere on the map.
<img width="974" alt="Screen Shot 2022-03-03 at 11 37 44 PM" src="https://user-images.githubusercontent.com/33613456/156700374-8d109de3-4b60-4594-964a-ee21f8095b11.png">

Problems right now: if you click a different annotation mode after point, the "on click" map event from the point mode is still active. Need to find a good way to disable/replace it when different modes are clicked.