### PR TITLE
Corrected padding and scrollbar look

### DIFF
--- a/frontend/src/components/KeywordOverview.css
+++ b/frontend/src/components/KeywordOverview.css
@@ -4,7 +4,7 @@
   left: 25px;
   padding: 20px;
   margin-right: 16px;
-  width: 20%;
+  width: 25%;
   min-width: 210px;
   height: 192px;
   border-radius: 4px;
@@ -28,4 +28,15 @@
   overflow-y: scroll;
   overflow-x: hidden;
   font-size: small;
+}
+
+.keyword-overview-list::-webkit-scrollbar {
+  -webkit-appearance: none;
+  width: 10px;
+}
+
+.keyword-overview-list::-webkit-scrollbar-thumb {
+  border-radius: 5px;
+  background-color: rgba(0, 0, 0, 0.5);
+  -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
 }

--- a/frontend/src/components/KeywordOverviewItem.css
+++ b/frontend/src/components/KeywordOverviewItem.css
@@ -1,3 +1,12 @@
 .keyword-overview-items {
   padding: 0;
 }
+
+.keyword-overview-label {
+  padding-right: 0 !important;
+}
+
+.keyword-overview-count {
+  padding-left: 0 !important;
+  padding-right: 20px !important;
+}

--- a/frontend/src/components/KeywordOverviewItem.tsx
+++ b/frontend/src/components/KeywordOverviewItem.tsx
@@ -12,7 +12,7 @@ function KeywordOverviewItem({ tagCount }: KeywordOverviewItemProps) {
 
   return (
     <div className="row keyword-overview-items" key={tag}>
-      <div className="col-10">
+      <div className="col-10 keyword-overview-label">
         {tag}
       </div>
       <div className="col-2 text-end keyword-overview-count">


### PR DESCRIPTION
<img width="1338" alt="image" src="https://user-images.githubusercontent.com/39637495/157162145-622079b7-d0da-4d20-b12d-e5c863c8bca7.png">
Scroll bar always shows in keyword overview panel now, padding should be fixed