### PR TITLE
Fixed polygon mode on tab change

### DIFF
--- a/frontend/src/components/AnnotationBar.tsx
+++ b/frontend/src/components/AnnotationBar.tsx
@@ -1,20 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './AnnotationBar.css';
 
 interface AnnotationBarProps {
   onAnnotationModeSelect: Function,
   annotationMode: string,
+  isSearchMode: Boolean,
 }
 
 function AnnotationBar({
   onAnnotationModeSelect,
   annotationMode,
+  isSearchMode,
 }: AnnotationBarProps) {
   const updateMode = (updatedMode: string) => {
     onAnnotationModeSelect(updatedMode);
   };
-  const polygonButtonClass = annotationMode === 'polygon' ? 'annotation-button polygon active' : 'annotation-button polygon';
-  const textButtonClass = annotationMode === 'text' ? 'annotation-button text active' : 'annotation-button text';
+  const [polygonButtonClass, setPolygonButtonClass] = useState('annotation-button polygon');
+  const [textButtonClass, setTextButtonClass] = useState('annotation-button text');
+
+  useEffect(() => {
+    if (isSearchMode) {
+      updateMode('');
+    } else {
+      setPolygonButtonClass((annotationMode === 'polygon') ? 'annotation-button polygon active' : 'annotation-button polygon');
+      setTextButtonClass((annotationMode === 'text') ? 'annotation-button text active' : 'annotation-button text');
+    }
+  }, [isSearchMode, annotationMode]);
 
   return (
     <div className="annotation-bar-container">

--- a/frontend/src/components/MapPanel.tsx
+++ b/frontend/src/components/MapPanel.tsx
@@ -70,7 +70,14 @@ function MapPanel({
   const onClickTextRef = useRef(onClickText);
   onClickTextRef.current = onClickText;
 
+  const updateAnnotationMode = (updatedMode: string) => {
+    setAnnotationMode(((annotationMode === updatedMode)) ? '' : updatedMode);
+  };
+
   useEffect(() => {
+    if (isSearchMode) {
+      updateAnnotationMode('');
+    }
     if (annotationMode === 'text' && textAnnotationLngLat && mapRef.current && !isSearchMode) {
       const map = mapRef.current;
       (textMarker as any).current = new mapboxgl.Marker({ color: '#D7CFBE' })
@@ -120,10 +127,6 @@ function MapPanel({
     }
   };
 
-  const updateAnnotationMode = (updatedMode: string) => {
-    setAnnotationMode((annotationMode === updatedMode) ? '' : updatedMode);
-  };
-
   const enableDrawingByMode = (map: any) => {
     switch (annotationMode) {
       case 'polygon':
@@ -139,6 +142,11 @@ function MapPanel({
 
       default:
         (mapRef as any).current.getCanvas().style.cursor = '';
+        try {
+          drawRef.current?.changeMode('simple_select');
+        } catch (e) {
+          console.log(e);
+        }
         map.off('click', onClickTextRef.current);
         break;
     }
@@ -303,6 +311,7 @@ function MapPanel({
             <AnnotationBar
               onAnnotationModeSelect={updateAnnotationMode}
               annotationMode={annotationMode}
+              isSearchMode={isSearchMode}
             />
             {annotationMode === 'text' ? (
               <Box


### PR DESCRIPTION
Functionally fixed but in a ugly way, wrapped in a try catch:

<img width="456" alt="Screen Shot 2022-03-08 at 11 36 53 AM" src="https://user-images.githubusercontent.com/33613456/157283103-83ebb29c-12d3-47bc-87ea-259919422953.png">

TypeError: Cannot read properties of undefined (reading 'getMode')
    at _e.e.getMode (api.js:170:1)
    at _e.e.changeMode (api.js:151:1)
    at enableDrawingByMode (MapPanel.tsx:147:1)
    at MapPanel.tsx:194:1
    at invokePassiveEffectCreate (react-dom.development.js:23487:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994:1)
    at invokeGuardedCallback (react-dom.development.js:4056:1)
    at flushPassiveEffectsImpl (react-dom.development.js:23574:1)
    at unstable_runWithPriority (scheduler.development.js:468:1)
