### PR TITLE
minor fixes for autocomplete and report select default

### DIFF
--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -65,7 +65,7 @@ function SearchPanel({
   const [timeRange, setTimeRange] = useState<number[]>(defaultTimeRange);
   const [reportCursor, setReportCursor] = useState(0);
   const [relCursor, setRelCursor] = useState(0);
-  const [sortReports, setSortReports] = useState('creationDate');
+  const [sortReports, setSortReports] = useState('name');
   const [sortRelationships, setSortRelationships] = useState('name');
 
   const handleReportCursorNext = () => setReportCursor(reportCursor + PAGE_LENGTH);

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -3,7 +3,7 @@ const hints = [
   'Rain and Snow',
   'Temperature',
   'Nature Restoration',
-  'Parks and Recreation',
+  'Recreation',
   'Homes',
   'Green Infrastructure',
   'Transit',


### PR DESCRIPTION
Small fixes for queenie: changed Parks and Recreation autocomplete option to Recreation (also updated in the database), changed the dropdown sort default for reports list to alphabetical

<img width="643" alt="image" src="https://user-images.githubusercontent.com/39637495/157287451-9c5bb7e0-ffff-4aa8-9fbe-12d0bb739e44.png">
<img width="831" alt="image" src="https://user-images.githubusercontent.com/39637495/157287493-9f941201-41b8-4bde-8a59-69dab471c989.png">
